### PR TITLE
Fast overlap and fast add of sparse matrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FLOYao"
 uuid = "6d9310a3-f1d0-41b7-8edb-11c1cf57cd2d"
 authors = ["janlukas.bosse <janlukas.bosse@gmail.com> and contributors"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/auto_diff.jl
+++ b/src/auto_diff.jl
@@ -38,9 +38,8 @@ function Yao.AD.backward_params!(st::Tuple{<:MajoranaReg,<:MajoranaReg},
     out, outδ = st
     ham = Yao.AD.generator(block)
     majoranaham = yaoham2majoranasquares(ham)
-    # multiply majoranaham with out.state and inner product with outδ.state
-    # i.e. g = outδ.state ⋅ (majoranaham * out.state) / 4
-    pushfirst!(collector, fast_overlap(outδ.state, majoranaham, out.state)/4)
+    g = fast_overlap(outδ.state, majoranaham, out.state) / 4
+    pushfirst!(collector, g)
     return nothing
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -350,8 +350,15 @@ end
 
 random_orthogonal_matrix(n) = random_orthogonal_matrix(Float64, n)
 
-# Fast sparse matrix operations
-# # compute A .+= B
+
+# -------------------------------------------
+# Utilities for fast sparse matrix operations
+# -------------------------------------------
+"""
+    fast_add!(A::AbstractMatrix, B::SparseMatrixCSC)
+
+Fast implementation of `A .+= B` for sparse `B`.
+"""
 function fast_add!(A::AbstractMatrix, B::SparseMatrixCSC)
     @assert size(A, 1) == size(B, 1) && size(A, 2) == size(B, 2) "Dimension mismatch"
     for j = 1:size(B, 2)
@@ -361,11 +368,16 @@ function fast_add!(A::AbstractMatrix, B::SparseMatrixCSC)
     end
     return A
 end
+
 function fast_add!(A::AbstractMatrix, B::AbstractMatrix)
     return A .+= B
 end
 
-# compute tr(y' * A * x)
+"""
+    fast_overlap(y::AbstractVecOrMat, A::SparseMatrixCSC, x::AbstractVecOrMat)
+
+Fast implementation of `tr(y' * A * x)` for sparse `A`.
+"""
 function fast_overlap(y::AbstractVecOrMat{T1}, A::SparseMatrixCSC{T2}, x::AbstractVecOrMat{T3}) where {T1,T2,T3}
     @assert size(x, 1) == size(A, 2) && size(y, 1) == size(A, 1) && size(x, 2) == size(y, 2) "Dimension mismatch"
     g = zero(promote_type(T1, T2, T3))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,24 @@ function ising_hamiltonian(nq, J, h)
     return hamiltonian
 end
 
+@testset "fast_overlap" begin
+    nq = 4
+    x = randn(ComplexF64, 10, 10)
+    y = randn(ComplexF64, 10, 10)
+    A = FLOYao.sprand(ComplexF64, 10, 10, 0.3)
+    r = FLOYao.fast_overlap(y, A, x)
+    @test isapprox(r, tr(y' * A * x), atol=1e-7)
+    @test isapprox(r, y ⋅ (A * x), atol=1e-7)
+end
+
+@testset "fast_add!" begin
+    A = randn(10, 10)
+    B = FLOYao.sprand(10, 10, 0.2)
+    C = copy(A)
+    @test FLOYao.fast_add!(C, B) ≈ A + B
+    @test FLOYao.fast_add!(C, Matrix(B)) ≈ A + B
+end
+
 @testset "MajoranaRegister" begin
     nq = 2
     mreg = FLOYao.zero_state(nq)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,7 @@ end
     B = FLOYao.sprand(10, 10, 0.2)
     C = copy(A)
     @test FLOYao.fast_add!(C, B) ≈ A + B
+    C = copy(A)
     @test FLOYao.fast_add!(C, Matrix(B)) ≈ A + B
 end
 


### PR DESCRIPTION
Nice package. I profiled the [transverse field ising model example](https://yaoquantum.org/FLOYao.jl/dev/vqe_example/#Example:-VQE-for-the-transverse-field-Ising-model) program and noticed some performance issues in this package.
This is a patch to improve the performance of sparse operations. Please review this PR carefully in case I made some stupid mistake.

## Benchmark
Before this patch, the time to run the example on my machine is
```
89.098484 seconds
```
After this patch, it could be reduced to
```
15.646890 seconds
```